### PR TITLE
Fix/Restoring the Navigation back stack

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "kr.ac.tukorea.android.earalarm"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "kr.ac.tukorea.android.earalarm"

--- a/build-logic/convention/src/main/kotlin/com/dev/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/com/dev/KotlinAndroid.kt
@@ -14,7 +14,7 @@ internal fun Project.configureKotlinAndroid() {
     }
 
     androidExtension.apply {
-        compileSdk = 34
+        compileSdk = 35
 
         defaultConfig {
             minSdk = 26

--- a/feature/setting/src/main/java/com/dev/earalarm/feature/setting/SettingScreen.kt
+++ b/feature/setting/src/main/java/com/dev/earalarm/feature/setting/SettingScreen.kt
@@ -219,6 +219,7 @@ private fun VolumeSetting(
         )
 
         Slider(
+            modifier = Modifier.padding(top = Paddings.large),
             value = volume.toFloat() / 100,
             onValueChange = { newVolume ->
                 setVolume((newVolume * 100).toInt())
@@ -232,7 +233,7 @@ private fun VolumeSetting(
                 firebaseManager.firebaseAnalytics.logEvent(FA.Event.SETTING_VOLUME_CHANGE) {
                     param(FA.Param.Key.VOLUME, volume.toLong())
                 }
-            }
+            },
         )
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,23 +1,23 @@
 [versions]
 ## Android gradle plugin
-androidGradlePlugin = "8.5.2"
+androidGradlePlugin = "8.9.0"
 
 androidDesugarJdkLibs = "2.0.4"
 
 ## AndroidX
-androidxCore = "1.13.1"
+androidxCore = "1.16.0"
 androidxAppCompat = "1.7.0"
-androidxLifecycle = "2.8.4"
-androidxActivity = "1.9.1"
+androidxLifecycle = "2.9.0"
+androidxActivity = "1.10.1"
 
 ## Compose
-androidxComposeBom = "2024.06.00"
-androidxComposeNavigation = "2.8.0-beta02"
-androidxComposeMaterial3 = "1.2.1"
+androidxComposeBom = "2025.05.01"
+androidxComposeNavigation = "2.9.0"
+androidxComposeMaterial3 = "1.3.2"
 material = "1.12.0"
 
 ## DataStore
-datastore = "1.1.4"
+datastore = "1.1.7"
 
 ## GSON
 gson = "2.10.1"
@@ -31,14 +31,14 @@ hiltNavigationCompose = "1.2.0"
 
 ## Kotlin
 kotlin = "2.0.0"
-kotlinxSerializationJson = "1.7.0"
+kotlinxSerializationJson = "1.7.3"
 kotlinxImmutable = "0.3.7"
 
 ## Coroutine
 coroutine = "1.9.0-RC"
 
 ## PlayStoreAds
-googlePlayAds = "24.2.0"
+googlePlayAds = "24.3.0"
 
 ##
 googlePlayReview = "2.0.2"
@@ -48,7 +48,7 @@ googlePlayAppUpdate = "2.1.0"
 google-services = "4.4.2"
 
 ## firebase
-firebase-bom = "33.13.0"
+firebase-bom = "33.14.0"
 firebase-crashlytics = "3.0.3"
 
 junit4 = "4.13.2"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8381d83b-887a-4b0a-bec2-0e6a77235b23)
![image](https://github.com/user-attachments/assets/13849f54-d5c9-4022-b581-bbbeb2382fc2)

```
Fatal Exception: java.lang.IllegalStateException
Restoring the Navigation back stack failed: destination 200282259 cannot be found from the current destination ComposeNavGraph(0x0) startDestination={Destination(0xf2c5eda) route=com.dev.earalarm.core.navigation.Route.Timer}
```
## 오류 시나리오
- 앱 실행 → 백그라운드로 전환 → 다른 앱 사용 → 현재 앱의 프로세스 종료 → 메뉴에서 재실행 → 오류 발생


## NavHost 관련 오류 수정 및 libs version 최신화
- compose navigation version 변경 2.8.0-beta02 -> 2.9.0
- compileSdk 34 -> 35 수정
- material3 Slider 디자인 변경으로 인한 padding 적용