### PR TITLE
Fix/In App Service launch ActivityResultLauncher

### DIFF
--- a/core/data/src/main/java/com/dev/earalarm/core/data/InAppServiceRepository.kt
+++ b/core/data/src/main/java/com/dev/earalarm/core/data/InAppServiceRepository.kt
@@ -1,0 +1,40 @@
+package com.dev.earalarm.core.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class InAppServiceRepository @Inject constructor(
+    private val dataStore: DataStore<Preferences>,
+) {
+
+    val lastReviewDate: Flow<String?> = dataStore.data.map {
+        it[LAST_REVIEW_DATE]
+    }.distinctUntilChanged()
+
+    val rejectFlexibleUpdateDate: Flow<String?> = dataStore.data.map {
+        it[REJECT_FLEXIBLE_UPDATE_DATE]
+    }.distinctUntilChanged()
+
+    suspend fun setLastReviewDate(reviewDate: String) {
+        dataStore.edit {
+            it[LAST_REVIEW_DATE] = reviewDate
+        }
+    }
+
+    suspend fun setRejectFlexibleUpdateDate(rejectFlexibleUpdateDate: String) {
+        dataStore.edit {
+            it[REJECT_FLEXIBLE_UPDATE_DATE] = rejectFlexibleUpdateDate
+        }
+    }
+
+    companion object {
+        val LAST_REVIEW_DATE = stringPreferencesKey("lastReviewDate")
+        val REJECT_FLEXIBLE_UPDATE_DATE = stringPreferencesKey("rejectFlexibleUpdateDate")
+    }
+}

--- a/core/data/src/main/java/com/dev/earalarm/core/data/TimerRepository.kt
+++ b/core/data/src/main/java/com/dev/earalarm/core/data/TimerRepository.kt
@@ -35,10 +35,6 @@ class TimerRepository @Inject constructor(
         gson.fromJson(it[TIMER_ALARM_INFO], TimerAlarmInfo::class.java)
     }.distinctUntilChanged()
 
-    val lastReviewDate: Flow<String?> = dataStore.data.map {
-        it[LAST_REVIEW_DATE]
-    }.distinctUntilChanged()
-
     suspend fun setAlarmVolume(volume: Int) {
         dataStore.edit {
             it[ALARM_VOLUME] = volume
@@ -75,18 +71,11 @@ class TimerRepository @Inject constructor(
         }
     }
 
-    suspend fun setLastReviewDate(reviewDate: String) {
-        dataStore.edit {
-            it[LAST_REVIEW_DATE] = reviewDate
-        }
-    }
-
     companion object {
         val ALARM_VOLUME = intPreferencesKey("volume")
         val MEDIA = stringPreferencesKey("media")
         val VIBRATE = booleanPreferencesKey("vibrate")
         val TIMER_ALARM_INFO = stringPreferencesKey("timerAlarmInfo")
-        val LAST_REVIEW_DATE = stringPreferencesKey("lastReviewDate")
 
         const val DEFAULT_VOLUME_SIZE = 80
     }

--- a/core/data/src/test/java/com/dev/earalarm/core/data/InAppServiceRepositoryTest.kt
+++ b/core/data/src/test/java/com/dev/earalarm/core/data/InAppServiceRepositoryTest.kt
@@ -1,0 +1,100 @@
+package com.dev.earalarm.core.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import app.cash.turbine.test
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.rules.TemporaryFolder
+
+internal class InAppServiceRepositoryTest : StringSpec() {
+
+    private lateinit var testDispatcher: TestDispatcher
+    private lateinit var tempFolder: TemporaryFolder
+
+    private lateinit var dataStore: DataStore<Preferences>
+    private lateinit var inAppServiceRepository: InAppServiceRepository
+
+    init {
+
+        beforeSpec {
+            testDispatcher = StandardTestDispatcher()
+            tempFolder = TemporaryFolder.builder().assureDeletion().build().apply { create() }
+
+            dataStore = PreferenceDataStoreFactory.create(
+                scope = CoroutineScope(testDispatcher),
+                produceFile = { tempFolder.newFile("inAppTest.preferences_pb") }
+            )
+            inAppServiceRepository = InAppServiceRepository(dataStore)
+        }
+
+        afterSpec {
+            tempFolder.delete()
+        }
+
+        "lastReviewDate 초기 상태 테스트" {
+            runTest(testDispatcher) {
+                // Given
+
+                // When
+                inAppServiceRepository.lastReviewDate.test {
+
+                    // Then
+                    awaitItem() shouldBe null
+                    cancelAndConsumeRemainingEvents()
+                }
+            }
+        }
+
+        "rejectFlexibleUpdateDate 초기 상태 테스트" {
+            runTest(testDispatcher) {
+                // Given
+
+                // When
+                inAppServiceRepository.rejectFlexibleUpdateDate.test {
+
+                    // Then
+                    awaitItem() shouldBe null
+                    cancelAndConsumeRemainingEvents()
+                }
+            }
+        }
+
+        "lastReviewDate 저장 및 조회 테스트" {
+            runTest(testDispatcher) {
+                // Given
+                val result = "2025-05-02T11:09:35.545010Z"
+                inAppServiceRepository.setLastReviewDate(result)
+
+                // When
+                inAppServiceRepository.lastReviewDate.test {
+
+                    // Then
+                    awaitItem() shouldBe result
+                    cancelAndConsumeRemainingEvents()
+                }
+            }
+        }
+
+        "rejectFlexibleUpdateDate 저장 및 조회 테스트" {
+            runTest(testDispatcher) {
+                // Given
+                val result = "2025-05-02T11:09:35.545010Z"
+                inAppServiceRepository.setRejectFlexibleUpdateDate(result)
+
+                // When
+                inAppServiceRepository.rejectFlexibleUpdateDate.test {
+
+                    // Then
+                    awaitItem() shouldBe result
+                    cancelAndConsumeRemainingEvents()
+                }
+            }
+        }
+    }
+}

--- a/core/data/src/test/java/com/dev/earalarm/core/data/TimerRepositoryTest.kt
+++ b/core/data/src/test/java/com/dev/earalarm/core/data/TimerRepositoryTest.kt
@@ -194,35 +194,5 @@ internal class TimerRepositoryTest : StringSpec() {
                 }
             }
         }
-
-        "lastReviewDate 초기 상태 테스트" {
-            runTest(testDispatcher) {
-                // Given
-
-                // When
-                timerRepository.lastReviewDate.test {
-
-                    // Then
-                    awaitItem() shouldBe null
-                    cancelAndConsumeRemainingEvents()
-                }
-            }
-        }
-
-        "lastReviewDate 저장 및 조회 테스트" {
-            runTest(testDispatcher) {
-                // Given
-                val result = "2025-05-02T11:09:35.545010Z"
-                timerRepository.setLastReviewDate(result)
-
-                // When
-                timerRepository.lastReviewDate.test {
-
-                    // Then
-                    awaitItem() shouldBe result
-                    cancelAndConsumeRemainingEvents()
-                }
-            }
-        }
     }
 }

--- a/feature/main/build.gradle.kts
+++ b/feature/main/build.gradle.kts
@@ -7,6 +7,8 @@ android {
 }
 
 dependencies {
+    implementation(libs.play.review.ktx)
+    implementation(libs.play.app.update.ktx)
     implementation(project(":feature:timer"))
     implementation(project(":feature:setting"))
 }

--- a/feature/main/src/main/java/com/dev/earalarm/feature/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/dev/earalarm/feature/main/MainScreen.kt
@@ -1,7 +1,9 @@
 package com.dev.earalarm.feature.main
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Snackbar
@@ -9,13 +11,20 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.dev.core.admob.LocalAdMobManager
 import com.dev.core.admob.banner.BannersAds
+import com.dev.earalarm.core.designsystem.theme.EarAlarmMaterialTheme
 import com.dev.earalarm.core.designsystem.theme.Paddings
+import com.dev.earalarm.feature.main.playservice.InAppReview
+import com.dev.earalarm.feature.main.playservice.InAppUpdate
 import com.dev.firebase.LocalFirebaseManager
 import com.dev.firebase.model.FA
 import com.google.firebase.analytics.logEvent
@@ -24,11 +33,14 @@ import kotlinx.coroutines.launch
 @Composable
 internal fun MainScreen(
     navigator: MainNavigator = rememberMainNavigator(),
+    mainViewModel: MainViewModel = hiltViewModel(),
 ) {
+    val mainUiState by mainViewModel.mainUiState.collectAsStateWithLifecycle()
     val snackBarHostState = remember { SnackbarHostState() }
     val firebaseManager = LocalFirebaseManager.current
     val coroutineScope = rememberCoroutineScope()
     val context = LocalContext.current
+
     val onShowErrorSnackBar: (throwable: Throwable?) -> Unit = { throwable ->
         coroutineScope.launch {
             val unknownErrorMessage = context.getString(R.string.feature_main_error_message_unknown)
@@ -40,21 +52,45 @@ internal fun MainScreen(
         }
     }
 
+    LaunchedEffect(Unit) {
+        mainViewModel.errorFlow.collect { throwable ->
+            onShowErrorSnackBar(throwable)
+        }
+    }
+
     MainScreenContent(
+        mainUiState = mainUiState,
         navigator = navigator,
         onShowErrorSnackBar = onShowErrorSnackBar,
         snackBarHostState = snackBarHostState,
+        setLastReviewDate = mainViewModel::setLastReviewDate,
+        setRejectFlexibleUpdateDate = mainViewModel::setRejectFlexibleUpdateDate,
     )
 }
 
 @Composable
 private fun MainScreenContent(
     modifier: Modifier = Modifier,
+    mainUiState: MainUiState,
     navigator: MainNavigator,
     onShowErrorSnackBar: (throwable: Throwable?) -> Unit,
     snackBarHostState: SnackbarHostState,
+    setLastReviewDate: () -> Unit,
+    setRejectFlexibleUpdateDate: () -> Unit,
 ) {
     val adMobManager = LocalAdMobManager.current
+    val flexibleSnackBarHostState = remember { SnackbarHostState() }
+
+    InAppReview(
+        lastReviewDate = mainUiState.lastReviewDate,
+        setLastReviewDate = setLastReviewDate
+    )
+
+    InAppUpdate(
+        snackBarHostState = flexibleSnackBarHostState,
+        rejectFlexibleUpdateDate = mainUiState.rejectFlexibleUpdateDate,
+        setRejectFlexibleUpdateDate = setRejectFlexibleUpdateDate
+    )
 
     Scaffold(
         modifier = modifier,
@@ -86,4 +122,32 @@ private fun MainScreenContent(
             }
         }
     )
+
+    SnackbarHost(
+        hostState = flexibleSnackBarHostState,
+        modifier = Modifier.systemBarsPadding(),
+    ) { data ->
+        Snackbar(
+            modifier = Modifier
+                .padding(Paddings.small)
+                .padding(top = Paddings.medium),
+            action = {
+                data.visuals.actionLabel?.let {
+                    Text(
+                        modifier = Modifier
+                            .padding(end = Paddings.small)
+                            .clickable { data.performAction() },
+                        text = it,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = EarAlarmMaterialTheme.colorScheme.active
+                    )
+                }
+            }
+        ) {
+            Text(
+                text = data.visuals.message,
+                style = MaterialTheme.typography.labelSmall
+            )
+        }
+    }
 }

--- a/feature/main/src/main/java/com/dev/earalarm/feature/main/MainUiState.kt
+++ b/feature/main/src/main/java/com/dev/earalarm/feature/main/MainUiState.kt
@@ -1,0 +1,10 @@
+package com.dev.earalarm.feature.main
+
+import androidx.compose.runtime.Immutable
+import java.time.ZonedDateTime
+
+@Immutable
+data class MainUiState(
+    val lastReviewDate: ZonedDateTime? = ZonedDateTime.now(),
+    val rejectFlexibleUpdateDate: ZonedDateTime? = ZonedDateTime.now(),
+)

--- a/feature/main/src/main/java/com/dev/earalarm/feature/main/MainViewModel.kt
+++ b/feature/main/src/main/java/com/dev/earalarm/feature/main/MainViewModel.kt
@@ -1,0 +1,74 @@
+package com.dev.earalarm.feature.main
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.dev.earalarm.core.data.InAppServiceRepository
+import com.dev.firebase.FirebaseManager
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import javax.inject.Inject
+
+@HiltViewModel
+class MainViewModel @Inject constructor(
+    private val inAppServiceRepository: InAppServiceRepository,
+    private val firebaseManager: FirebaseManager,
+) : ViewModel() {
+
+    private val _errorFlow = MutableSharedFlow<Throwable>()
+    val errorFlow get() = _errorFlow.asSharedFlow()
+
+    private val _mainUiState = MutableStateFlow(MainUiState())
+    val mainUiState = _mainUiState.stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(5_000),
+        _mainUiState.value
+    )
+
+    init {
+        loadServiceData()
+    }
+
+    private fun loadServiceData() {
+        combine(
+            inAppServiceRepository.lastReviewDate,
+            inAppServiceRepository.rejectFlexibleUpdateDate
+        ) { lastReviewDate, rejectFlexibleUpdateDate ->
+            _mainUiState.update {
+                it.copy(
+                    lastReviewDate = lastReviewDate?.let { ZonedDateTime.parse(it) },
+                    rejectFlexibleUpdateDate = rejectFlexibleUpdateDate?.let {
+                        ZonedDateTime.parse(it)
+                    }
+                )
+            }
+        }.catch { throwable ->
+            firebaseManager.reportNonFatalError(throwable)
+            _errorFlow.emit(throwable)
+        }.launchIn(viewModelScope)
+    }
+
+    fun setLastReviewDate() {
+        viewModelScope.launch {
+            val currentDate = ZonedDateTime.now(ZoneOffset.UTC).toString()
+            inAppServiceRepository.setLastReviewDate(currentDate)
+        }
+    }
+
+    fun setRejectFlexibleUpdateDate() {
+        viewModelScope.launch {
+            val currentDate = ZonedDateTime.now(ZoneOffset.UTC).toString()
+            inAppServiceRepository.setRejectFlexibleUpdateDate(currentDate)
+        }
+    }
+}

--- a/feature/main/src/main/java/com/dev/earalarm/feature/main/playservice/InAppReview.kt
+++ b/feature/main/src/main/java/com/dev/earalarm/feature/main/playservice/InAppReview.kt
@@ -1,4 +1,4 @@
-package com.dev.earalarm.feature.timer.playservice
+package com.dev.earalarm.feature.main.playservice
 
 import android.app.Activity
 import androidx.compose.runtime.Composable

--- a/feature/main/src/main/java/com/dev/earalarm/feature/main/playservice/InAppUpdate.kt
+++ b/feature/main/src/main/java/com/dev/earalarm/feature/main/playservice/InAppUpdate.kt
@@ -1,4 +1,4 @@
-package com.dev.earalarm.feature.timer.playservice
+package com.dev.earalarm.feature.main.playservice
 
 import android.app.Activity
 import android.content.Context
@@ -19,7 +19,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.dev.earalarm.feature.timer.R
+import com.dev.earalarm.feature.main.R
 import com.dev.firebase.LocalFirebaseManager
 import com.google.android.play.core.appupdate.AppUpdateManager
 import com.google.android.play.core.appupdate.AppUpdateManagerFactory
@@ -29,14 +29,16 @@ import com.google.android.play.core.install.model.AppUpdateType
 import com.google.android.play.core.install.model.InstallStatus
 import com.google.android.play.core.install.model.UpdateAvailability
 import kotlinx.coroutines.launch
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
 
 private const val MIN_VERSION_DIFF_FOR_IMMEDIATE_UPDATE = 5L
 
 @Composable
 internal fun InAppUpdate(
     snackBarHostState: SnackbarHostState,
-    isRejectFlexibleUpdate: Boolean,
-    rejectFlexibleUpdate: () -> Unit,
+    rejectFlexibleUpdateDate: ZonedDateTime?,
+    setRejectFlexibleUpdateDate: () -> Unit,
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -59,7 +61,7 @@ internal fun InAppUpdate(
         ActivityResultContracts.StartIntentSenderForResult(),
     ) { result ->
         if (result.resultCode != Activity.RESULT_OK) {
-            rejectFlexibleUpdate()
+            setRejectFlexibleUpdateDate()
         }
     }
 
@@ -70,8 +72,8 @@ internal fun InAppUpdate(
                     showFlexibleUpdateSnackBar(
                         snackBarHostState,
                         appUpdateManager,
-                        context.getString(R.string.feature_timer_update_complete),
-                        context.getString(R.string.feature_timer_update_install)
+                        context.getString(R.string.feature_main_update_complete),
+                        context.getString(R.string.feature_main_update_install)
                     )
                 }
             }
@@ -85,8 +87,9 @@ internal fun InAppUpdate(
         }
     }
 
-    LaunchedEffect(Unit) {
+    LaunchedEffect(rejectFlexibleUpdateDate) {
         try {
+            val now = ZonedDateTime.now(ZoneOffset.UTC)
             val versionCode = getAppVersionCode(context)
             val appUpdateInfoTask = appUpdateManager.appUpdateInfo
             appUpdateInfoTask.addOnSuccessListener { appUpdateInfo ->
@@ -99,7 +102,7 @@ internal fun InAppUpdate(
                 val availableFlexible =
                     appUpdateInfo.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE
                             && appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.FLEXIBLE)
-                            && !isRejectFlexibleUpdate
+                            && rejectFlexibleUpdateDate?.plusDays(1)?.isBefore(now) ?: true
 
                 when {
                     availableImmediate -> {
@@ -145,8 +148,8 @@ internal fun InAppUpdate(
                             showFlexibleUpdateSnackBar(
                                 snackBarHostState,
                                 appUpdateManager,
-                                context.getString(R.string.feature_timer_update_complete),
-                                context.getString(R.string.feature_timer_update_install)
+                                context.getString(R.string.feature_main_update_complete),
+                                context.getString(R.string.feature_main_update_install)
                             )
                         }
                     }

--- a/feature/main/src/main/res/values-es/string.xml
+++ b/feature/main/src/main/res/values-es/string.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="feature_main_error_message_unknown">Se ha producido un error desconocido.</string>
+
+    <string name="feature_main_update_complete">Descarga de actualización completa</string>
+    <string name="feature_main_update_install">Instalar</string>
 </resources>

--- a/feature/main/src/main/res/values-fr/string.xml
+++ b/feature/main/src/main/res/values-fr/string.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="feature_main_error_message_unknown">Une erreur inconnue est survenue.</string>
+
+    <string name="feature_main_update_complete">Téléchargement de la mise à jour terminé</string>
+    <string name="feature_main_update_install">Installer</string>
 </resources>

--- a/feature/main/src/main/res/values-in/string.xml
+++ b/feature/main/src/main/res/values-in/string.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="feature_main_error_message_unknown">Terjadi kesalahan yang tidak diketahui.</string>
+
+    <string name="feature_main_update_complete">Unduhan pembaruan selesai</string>
+    <string name="feature_main_update_install">Pasang</string>
 </resources>

--- a/feature/main/src/main/res/values-ja/string.xml
+++ b/feature/main/src/main/res/values-ja/string.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="feature_main_error_message_unknown">不明なエラーが発生しました。</string>
+
+    <string name="feature_main_update_complete">アップデートのダウンロードが完了しました</string>
+    <string name="feature_main_update_install">インストール</string>
 </resources>

--- a/feature/main/src/main/res/values-ko-rKR/strings.xml
+++ b/feature/main/src/main/res/values-ko-rKR/strings.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="feature_main_error_message_unknown">알 수 없는 에러가 발생하였습니다.</string>
+
+    <string name="feature_main_update_complete">업데이트 설치 완료</string>
+    <string name="feature_main_update_install">설치</string>
 </resources>

--- a/feature/main/src/main/res/values-zh-rCN/strings.xml
+++ b/feature/main/src/main/res/values-zh-rCN/strings.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="feature_main_error_message_unknown">发生了未知错误。</string>
+
+    <string name="feature_main_update_complete">更新下载完成</string>
+    <string name="feature_main_update_install">安装</string>
 </resources>

--- a/feature/main/src/main/res/values-zh-rTW/string.xml
+++ b/feature/main/src/main/res/values-zh-rTW/string.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="feature_main_error_message_unknown">發生未知錯誤。</string>
+
+    <string name="feature_main_update_complete">更新下載完成</string>
+    <string name="feature_main_update_install">安裝</string>
 </resources>

--- a/feature/main/src/main/res/values/strings.xml
+++ b/feature/main/src/main/res/values/strings.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="feature_main_error_message_unknown">An unknown error has occurred.</string>
+
+    <string name="feature_main_update_complete">Update download complete</string>
+    <string name="feature_main_update_install">Install</string>
 </resources>

--- a/feature/main/src/test/java/com/dev/earalarm/feature/main/MainViewModelTest.kt
+++ b/feature/main/src/test/java/com/dev/earalarm/feature/main/MainViewModelTest.kt
@@ -1,0 +1,128 @@
+package com.dev.earalarm.feature.main
+
+import app.cash.turbine.test
+import com.dev.earalarm.core.data.InAppServiceRepository
+import com.dev.firebase.FakeFirebaseManager
+import com.dev.firebase.FirebaseManager
+import com.dev.testing.rule.MainDispatcherRule
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.util.Locale
+import kotlin.test.assertEquals
+
+internal class MainViewModelTest {
+
+    @get:Rule
+    var mainCoroutineRule = MainDispatcherRule()
+
+    private val inAppServiceRepository: InAppServiceRepository = mockk(relaxed = true)
+    private val firebaseManager: FirebaseManager = FakeFirebaseManager()
+    private lateinit var mainViewModel: MainViewModel
+
+    @Before
+    fun setUp() {
+        mockkStatic(ZonedDateTime::class)
+        mockkStatic(ZoneId::class)
+
+        every { ZoneId.systemDefault() } returns ZoneId.of("Asia/Seoul")
+        every { ZonedDateTime.now() } returns ZonedDateTime.parse("2025-05-01T00:00:00.000000Z")
+        Locale.setDefault(Locale.US)
+    }
+
+    @Test
+    fun `마지막 리뷰 요청 시간과, 유연한 업데이트 거절 시간을 확인할 수 있다`() = runTest {
+
+        // Given
+        mainViewModel = MainViewModel(inAppServiceRepository, firebaseManager)
+
+        val lastReviewDate = "2025-05-01T00:00:00.000000Z"
+        val rejectFlexibleUpdateDate = "2025-05-01T00:00:00.000000Z"
+
+        coEvery { inAppServiceRepository.lastReviewDate } returns flowOf(lastReviewDate)
+        coEvery { inAppServiceRepository.rejectFlexibleUpdateDate } returns flowOf(
+            rejectFlexibleUpdateDate
+        )
+
+        // When
+        mainViewModel.mainUiState.test {
+
+            // Then
+            val uiState = awaitItem()
+            assertEquals(
+                MainUiState(
+                    lastReviewDate = ZonedDateTime.parse(lastReviewDate),
+                    rejectFlexibleUpdateDate = ZonedDateTime.parse(rejectFlexibleUpdateDate)
+                ),
+                uiState
+            )
+        }
+    }
+
+    @Test
+    fun `마지막 리뷰 요청 시간을 갱신할 수 있다`() = runTest {
+
+        // Given
+        mainViewModel = MainViewModel(inAppServiceRepository, firebaseManager)
+
+        val lastReviewDate = "2025-05-01T00:00:00.000000Z"
+        val flow = MutableStateFlow<String?>(null)
+
+        coEvery { inAppServiceRepository.lastReviewDate } returns flow
+        coEvery { inAppServiceRepository.rejectFlexibleUpdateDate } returns flowOf(null)
+
+        coEvery { inAppServiceRepository.setRejectFlexibleUpdateDate(lastReviewDate) } answers {
+            flow.value = lastReviewDate
+        }
+
+        // When
+        mainViewModel.setLastReviewDate()
+
+        // Then
+        mainViewModel.mainUiState.test {
+            val uiState = awaitItem()
+            assertEquals(
+                ZonedDateTime.now(),
+                uiState.lastReviewDate
+            )
+        }
+    }
+
+    @Test
+    fun `유연한 업데이트 거절시간을 갱신할 수 있다`() = runTest {
+
+        // Given
+        mainViewModel = MainViewModel(inAppServiceRepository, firebaseManager)
+
+        val rejectFlexibleUpdateDate = "2025-05-01T00:00:00.000000Z"
+        val flow = MutableStateFlow<String?>(null)
+
+        coEvery { inAppServiceRepository.lastReviewDate } returns flowOf(null)
+        coEvery { inAppServiceRepository.rejectFlexibleUpdateDate } returns flow
+
+        coEvery { inAppServiceRepository.setRejectFlexibleUpdateDate(rejectFlexibleUpdateDate) } answers {
+            flow.value = rejectFlexibleUpdateDate
+        }
+
+        // When
+        mainViewModel.setRejectFlexibleUpdateDate()
+
+        // Then
+        mainViewModel.mainUiState.test {
+            val uiState = awaitItem()
+            assertEquals(
+                ZonedDateTime.now(),
+                uiState.rejectFlexibleUpdateDate
+            )
+        }
+    }
+}

--- a/feature/timer/build.gradle.kts
+++ b/feature/timer/build.gradle.kts
@@ -7,7 +7,5 @@ android {
 }
 
 dependencies {
-    implementation(libs.play.review.ktx)
-    implementation(libs.play.app.update.ktx)
     implementation(project(":core:alarm"))
 }

--- a/feature/timer/src/main/java/com/dev/earalarm/feature/timer/TimerScreen.kt
+++ b/feature/timer/src/main/java/com/dev/earalarm/feature/timer/TimerScreen.kt
@@ -1,13 +1,20 @@
 package com.dev.earalarm.feature.timer
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.dev.earalarm.core.designsystem.theme.EarAlarmMaterialTheme
 import com.dev.earalarm.feature.timer.home.HomeScreen
 import com.dev.earalarm.feature.timer.measure.MeasureScreen
+import com.dev.earalarm.feature.timer.model.TimerState
 
 @Composable
 internal fun TimerScreen(
@@ -16,7 +23,7 @@ internal fun TimerScreen(
     navigateToSetting: () -> Unit,
     timerViewModel: TimerViewModel = hiltViewModel(),
 ) {
-    val hasTimer by timerViewModel.hasTimer.collectAsStateWithLifecycle()
+    val timerState by timerViewModel.timerState.collectAsStateWithLifecycle()
 
     LaunchedEffect(Unit) {
         timerViewModel.errorFlow.collect { throwable ->
@@ -24,16 +31,29 @@ internal fun TimerScreen(
         }
     }
 
-    if (!hasTimer) {
-        HomeScreen(
-            paddingValues = paddingValues,
-            onShowErrorSnackBar = onShowErrorSnackBar,
-            navigateToSetting = navigateToSetting
-        )
-    } else {
-        MeasureScreen(
-            paddingValues = paddingValues,
-            onShowErrorSnackBar = onShowErrorSnackBar,
-        )
+    when (timerState) {
+        is TimerState.Home -> {
+            HomeScreen(
+                paddingValues = paddingValues,
+                onShowErrorSnackBar = onShowErrorSnackBar,
+                navigateToSetting = navigateToSetting
+            )
+        }
+
+        is TimerState.Measure -> {
+            MeasureScreen(
+                paddingValues = paddingValues,
+                onShowErrorSnackBar = onShowErrorSnackBar,
+            )
+        }
+
+        is TimerState.Loading -> {
+            Box(modifier = Modifier.fillMaxSize()) {
+                CircularProgressIndicator(
+                    modifier = Modifier.align(Alignment.Center),
+                    color = EarAlarmMaterialTheme.colorScheme.active
+                )
+            }
+        }
     }
 }

--- a/feature/timer/src/main/java/com/dev/earalarm/feature/timer/TimerViewModel.kt
+++ b/feature/timer/src/main/java/com/dev/earalarm/feature/timer/TimerViewModel.kt
@@ -3,6 +3,7 @@ package com.dev.earalarm.feature.timer
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.dev.earalarm.core.data.TimerRepository
+import com.dev.earalarm.feature.timer.model.TimerState
 import com.dev.firebase.FirebaseManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -22,15 +23,20 @@ class TimerViewModel @Inject constructor(
     private val _errorFlow = MutableSharedFlow<Throwable>()
     val errorFlow get() = _errorFlow.asSharedFlow()
 
-    val hasTimer = timerRepository.alarmInfo
-        .map { it != null }
+    val timerState = timerRepository.alarmInfo
+        .map {
+            if (it == null) {
+                TimerState.Home
+            } else {
+                TimerState.Measure
+            }
+        }
         .catch { throwable ->
             firebaseManager.reportNonFatalError(throwable)
             _errorFlow.emit(throwable)
-        }
-        .stateIn(
+        }.stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5_000),
-            initialValue = false
+            initialValue = TimerState.Loading
         )
 }

--- a/feature/timer/src/main/java/com/dev/earalarm/feature/timer/home/HomeScreen.kt
+++ b/feature/timer/src/main/java/com/dev/earalarm/feature/timer/home/HomeScreen.kt
@@ -19,13 +19,9 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Snackbar
-import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -59,8 +55,6 @@ import com.dev.earalarm.feature.timer.component.TimerControlButtons
 import com.dev.earalarm.feature.timer.component.WheelPicker
 import com.dev.earalarm.feature.timer.model.HomeUiState
 import com.dev.earalarm.feature.timer.model.PermissionState
-import com.dev.earalarm.feature.timer.playservice.InAppReview
-import com.dev.earalarm.feature.timer.playservice.InAppUpdate
 import com.dev.firebase.LocalFirebaseManager
 import com.dev.firebase.model.FA
 import com.google.firebase.analytics.logEvent
@@ -79,7 +73,6 @@ internal fun HomeScreen(
     val homeUiState by homeViewModel.homeUiState.collectAsStateWithLifecycle()
     val firebaseManager = LocalFirebaseManager.current
     val configuration = LocalConfiguration.current
-    val flexibleSnackBarHostState = remember { SnackbarHostState() }
 
     LaunchedEffect(Unit) {
         firebaseManager.screenLogEvent("HomeScreen", configuration.orientation)
@@ -87,17 +80,6 @@ internal fun HomeScreen(
             onShowErrorSnackBar(throwable)
         }
     }
-
-    InAppUpdate(
-        snackBarHostState = flexibleSnackBarHostState,
-        isRejectFlexibleUpdate = homeUiState.isRejectFlexibleUpdate,
-        rejectFlexibleUpdate = homeViewModel::rejectFlexibleUpdate
-    )
-
-    InAppReview(
-        lastReviewDate = homeUiState.lastReviewDate,
-        setLastReviewDate = homeViewModel::setLastReviewDate
-    )
 
     HomeContent(
         homeUiState = homeUiState,
@@ -109,34 +91,6 @@ internal fun HomeScreen(
         startTimerAlarm = homeViewModel::startTimerAlarm,
         updateTimerAlarm = homeViewModel::updateTimerAlarm,
     )
-
-    SnackbarHost(
-        hostState = flexibleSnackBarHostState,
-        modifier = Modifier.systemBarsPadding(),
-    ) { data ->
-        Snackbar(
-            modifier = Modifier
-                .padding(Paddings.small)
-                .padding(top = Paddings.medium),
-            action = {
-                data.visuals.actionLabel?.let {
-                    Text(
-                        modifier = Modifier
-                            .padding(end = Paddings.small)
-                            .clickable { data.performAction() },
-                        text = it,
-                        style = MaterialTheme.typography.labelSmall,
-                        color = EarAlarmMaterialTheme.colorScheme.active
-                    )
-                }
-            }
-        ) {
-            Text(
-                text = data.visuals.message,
-                style = MaterialTheme.typography.labelSmall
-            )
-        }
-    }
 }
 
 @Composable

--- a/feature/timer/src/main/java/com/dev/earalarm/feature/timer/home/HomeViewModel.kt
+++ b/feature/timer/src/main/java/com/dev/earalarm/feature/timer/home/HomeViewModel.kt
@@ -50,13 +50,11 @@ class HomeViewModel @Inject constructor(
         combine(
             timerRepository.alarmVolume,
             timerRepository.media,
-            timerRepository.lastReviewDate
-        ) { volume, media, lastReviewDate ->
+        ) { volume, media ->
             _homeUiState.update {
                 it.copy(
                     volume = volume,
                     alarmMedia = media,
-                    lastReviewDate = lastReviewDate?.let { ZonedDateTime.parse(it) }
                 )
             }
         }.catch { throwable ->
@@ -116,21 +114,6 @@ class HomeViewModel @Inject constructor(
             it.copy(
                 deniedNotificationDialog = false,
                 deniedExactAlarmDialog = false,
-            )
-        }
-    }
-
-    fun setLastReviewDate() {
-        viewModelScope.launch {
-            val currentDate = ZonedDateTime.now(ZoneOffset.UTC).toString()
-            timerRepository.setLastReviewDate(currentDate)
-        }
-    }
-
-    fun rejectFlexibleUpdate() {
-        _homeUiState.update {
-            it.copy(
-                isRejectFlexibleUpdate = true
             )
         }
     }

--- a/feature/timer/src/main/java/com/dev/earalarm/feature/timer/model/HomeUiState.kt
+++ b/feature/timer/src/main/java/com/dev/earalarm/feature/timer/model/HomeUiState.kt
@@ -2,7 +2,6 @@ package com.dev.earalarm.feature.timer.model
 
 import androidx.compose.runtime.Immutable
 import java.io.File
-import java.time.ZonedDateTime
 
 @Immutable
 data class HomeUiState(
@@ -14,6 +13,4 @@ data class HomeUiState(
     val notificationPermissionState: PermissionState = PermissionState.GRANTED,
     val deniedExactAlarmDialog: Boolean = false,
     val deniedNotificationDialog: Boolean = false,
-    val lastReviewDate: ZonedDateTime? = ZonedDateTime.now(),
-    val isRejectFlexibleUpdate: Boolean = false,
 )

--- a/feature/timer/src/main/java/com/dev/earalarm/feature/timer/model/TimerState.kt
+++ b/feature/timer/src/main/java/com/dev/earalarm/feature/timer/model/TimerState.kt
@@ -1,0 +1,7 @@
+package com.dev.earalarm.feature.timer.model
+
+sealed class TimerState {
+    data object Home : TimerState()
+    data object Measure : TimerState()
+    data object Loading : TimerState()
+}

--- a/feature/timer/src/main/res/values-es/string.xml
+++ b/feature/timer/src/main/res/values-es/string.xml
@@ -28,7 +28,4 @@
 
     <string name="feature_timer_permission_positive">Sí</string>
     <string name="feature_timer_permission_negative">No</string>
-
-    <string name="feature_timer_update_complete">Descarga de actualización completa</string>
-    <string name="feature_timer_update_install">Instalar</string>
 </resources>

--- a/feature/timer/src/main/res/values-fr/string.xml
+++ b/feature/timer/src/main/res/values-fr/string.xml
@@ -28,7 +28,4 @@
 
     <string name="feature_timer_permission_positive">Oui</string>
     <string name="feature_timer_permission_negative">Non</string>
-
-    <string name="feature_timer_update_complete">Téléchargement de la mise à jour terminé</string>
-    <string name="feature_timer_update_install">Installer</string>
 </resources>

--- a/feature/timer/src/main/res/values-in/string.xml
+++ b/feature/timer/src/main/res/values-in/string.xml
@@ -28,7 +28,4 @@
 
     <string name="feature_timer_permission_positive">Ya</string>
     <string name="feature_timer_permission_negative">Tidak</string>
-
-    <string name="feature_timer_update_complete">Unduhan pembaruan selesai</string>
-    <string name="feature_timer_update_install">Pasang</string>
 </resources>

--- a/feature/timer/src/main/res/values-ja/string.xml
+++ b/feature/timer/src/main/res/values-ja/string.xml
@@ -28,7 +28,4 @@
 
     <string name="feature_timer_permission_positive">はい</string>
     <string name="feature_timer_permission_negative">いいえ</string>
-
-    <string name="feature_timer_update_complete">アップデートのダウンロードが完了しました</string>
-    <string name="feature_timer_update_install">インストール</string>
 </resources>

--- a/feature/timer/src/main/res/values-ko-rKR/strings.xml
+++ b/feature/timer/src/main/res/values-ko-rKR/strings.xml
@@ -28,7 +28,4 @@
 
     <string name="feature_timer_permission_positive">네</string>
     <string name="feature_timer_permission_negative">아니오</string>
-
-    <string name="feature_timer_update_complete">업데이트 설치 완료</string>
-    <string name="feature_timer_update_install">설치</string>
 </resources>

--- a/feature/timer/src/main/res/values-zh-rCN/strings.xml
+++ b/feature/timer/src/main/res/values-zh-rCN/strings.xml
@@ -28,7 +28,4 @@
 
     <string name="feature_timer_permission_positive">是</string>
     <string name="feature_timer_permission_negative">否</string>
-
-    <string name="feature_timer_update_complete">更新下载完成</string>
-    <string name="feature_timer_update_install">安装</string>
 </resources>

--- a/feature/timer/src/main/res/values-zh-rTW/string.xml
+++ b/feature/timer/src/main/res/values-zh-rTW/string.xml
@@ -28,7 +28,4 @@
 
     <string name="feature_timer_permission_positive">是</string>
     <string name="feature_timer_permission_negative">否</string>
-
-    <string name="feature_timer_update_complete">更新下載完成</string>
-    <string name="feature_timer_update_install">安裝</string>
 </resources>

--- a/feature/timer/src/main/res/values/strings.xml
+++ b/feature/timer/src/main/res/values/strings.xml
@@ -28,7 +28,4 @@
 
     <string name="feature_timer_permission_positive">Yes</string>
     <string name="feature_timer_permission_negative">No</string>
-
-    <string name="feature_timer_update_complete">Update download complete</string>
-    <string name="feature_timer_update_install">Install</string>
 </resources>

--- a/feature/timer/src/test/java/com/dev/earalarm/feature/setting/HomeViewModelTest.kt
+++ b/feature/timer/src/test/java/com/dev/earalarm/feature/setting/HomeViewModelTest.kt
@@ -39,11 +39,9 @@ internal class HomeViewModelTest {
         // Given
         val alarmVolume = 100
         val media = "/files/test.m4a"
-        val lastReviewDate = "2025-05-01T00:00:00.000000Z"
 
         coEvery { timerRepository.alarmVolume } returns flowOf(alarmVolume)
         coEvery { timerRepository.media } returns flowOf(File(media))
-        coEvery { timerRepository.lastReviewDate } returns flowOf(lastReviewDate)
 
         homeViewModel = HomeViewModel(timerRepository, earAlarmManager, firebaseManager)
 
@@ -54,7 +52,6 @@ internal class HomeViewModelTest {
             val uiState = awaitItem()
             assertEquals(alarmVolume, uiState.volume)
             assertEquals(File(media), uiState.alarmMedia)
-            assertEquals(ZonedDateTime.parse(lastReviewDate), uiState.lastReviewDate)
         }
     }
 
@@ -155,26 +152,6 @@ internal class HomeViewModelTest {
             val uiState = awaitItem()
             assertEquals(false, uiState.deniedNotificationDialog)
             assertEquals(false, uiState.deniedExactAlarmDialog)
-        }
-    }
-
-    @Test
-    fun `리뷰 요청을 거절할 수 있다`() = runTest {
-
-        // Given
-        homeViewModel = HomeViewModel(timerRepository, earAlarmManager, firebaseManager)
-
-
-        homeViewModel.homeUiState.test {
-            var uiState = awaitItem()
-            assertEquals(false, uiState.isRejectFlexibleUpdate)
-
-            // When
-            homeViewModel.rejectFlexibleUpdate()
-
-            // Then
-            uiState = awaitItem()
-            assertEquals(true, uiState.isRejectFlexibleUpdate)
         }
     }
 }

--- a/feature/timer/src/test/java/com/dev/earalarm/feature/setting/TimerViewModelTest.kt
+++ b/feature/timer/src/test/java/com/dev/earalarm/feature/setting/TimerViewModelTest.kt
@@ -4,6 +4,7 @@ import app.cash.turbine.test
 import com.dev.earalarm.core.data.TimerRepository
 import com.dev.earalarm.core.model.TimerAlarmInfo
 import com.dev.earalarm.feature.timer.TimerViewModel
+import com.dev.earalarm.feature.timer.model.TimerState
 import com.dev.firebase.FakeFirebaseManager
 import com.dev.firebase.FirebaseManager
 import com.dev.testing.rule.MainDispatcherRule
@@ -13,8 +14,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
+import kotlin.test.assertEquals
 
 internal class TimerViewModelTest {
 
@@ -26,23 +26,23 @@ internal class TimerViewModelTest {
     private lateinit var timerViewModel: TimerViewModel
 
     @Test
-    fun `저장된 타이머 데이터가 있으면 true를 반환한다`() = runTest {
+    fun `저장된 타이머 데이터가 있으면 Measure를 반환한다`() = runTest {
 
         // Given
         coEvery { timerRepository.alarmInfo } returns flowOf(fakeTimerAlarmInfo)
         timerViewModel = TimerViewModel(timerRepository, firebaseManager)
 
         // When
-        timerViewModel.hasTimer.test {
+        timerViewModel.timerState.test {
 
             // Then
             val actual = awaitItem()
-            assertTrue(actual)
+            assertEquals(TimerState.Measure, actual)
         }
     }
 
     @Test
-    fun `저장된 타이머 데이터가 없으면 false를 반환한다`() = runTest {
+    fun `저장된 타이머 데이터가 없으면 Home을 반환한다`() = runTest {
 
         // Given
         coEvery { timerRepository.alarmInfo } returns flowOf(null)
@@ -50,11 +50,11 @@ internal class TimerViewModelTest {
 
 
         // When
-        timerViewModel.hasTimer.test {
+        timerViewModel.timerState.test {
 
             // Then
             val actual = awaitItem()
-            assertFalse(actual)
+            assertEquals(TimerState.Home, actual)
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ androidxComposeMaterial3 = "1.3.2"
 material = "1.12.0"
 
 ## DataStore
-datastore = "1.1.7"
+datastore = "1.1.4"
 
 ## GSON
 gson = "2.10.1"


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/308c3f0d-2484-41bb-8fb1-905ac20d12dc)
![image](https://github.com/user-attachments/assets/068522a9-148e-4f4a-91c8-083ce06df60d)
```
Fatal Exception: java.lang.IllegalStateException
Attempting to launch an unregistered ActivityResultLauncher with contract androidx.activity.result.contract.ActivityResultContracts$StartIntentSenderForResult@4372099 and input androidx.activity.result.IntentSenderRequest@6bdaf5e. You must ensure the ActivityResultLauncher is registered before calling launch().
```
## 오류 시나리오
- 유연한 업데이트 가능 상태 → HomeScreen 진입 → startUpdateFlowForResult 호출 → 설정된 타이머 있을 경우 바로 TimerScreen 전환되면서 HomeScreen 컴포저블 종료 → ResultLauncher 사라짐 → startUpdateFlowForResult 에서 ResultLauncher 등록 안됨 → 오류 발생

## In App Service launch ActivityResultLauncher 관련 오류 수정
- HomeScreen에서 rememberLauncherForActivityResult로 저장된 ResultLauncher가 startUpdateFlowForResult 호출 이후 시점에서 사라졌을 경우 발생하는 오류로 확인
- 유연한 업데이트의 경우, HomeScreen은 앱을 사용하는 도중 사라질 가능성이 크기 때문에 MainScreen에서 업데이트 검사 및 요청
- 인앱 업데이트 및 인앱 리뷰 요청 로직을 MainScreen으로 이동
- 인앱 리뷰와 유연한 업데이트의 거절 데이터 Repository 분리
- 유연한 업데이트 요청 주기를 하루로 변경
- Timer Screen에서 데이터 로딩 화면 추가
- Data Store libs version 테스트 안정화 문제로 인한 1.1.4로 변경
