### PR TITLE
Fix/직렬화 라이브러리 통합 및 난독화 예외 적용

### DIFF
--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("earalarm.android.library")
+    id("earalarm.android.kotlin.serialization")
 }
 
 android {
@@ -7,7 +8,6 @@ android {
 }
 
 dependencies {
-    implementation(libs.gson)
     implementation(libs.datastore.preferences)
 
     implementation(project(":core:model"))

--- a/core/data/src/main/java/com/dev/earalarm/core/data/TimerRepository.kt
+++ b/core/data/src/main/java/com/dev/earalarm/core/data/TimerRepository.kt
@@ -7,16 +7,16 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.dev.earalarm.core.model.TimerAlarmInfo
-import com.google.gson.Gson
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import java.io.File
 import javax.inject.Inject
 
 class TimerRepository @Inject constructor(
     private val dataStore: DataStore<Preferences>,
-    private val gson: Gson,
 ) {
 
     val alarmVolume: Flow<Int> = dataStore.data.map {
@@ -32,7 +32,9 @@ class TimerRepository @Inject constructor(
     }.distinctUntilChanged()
 
     val alarmInfo: Flow<TimerAlarmInfo?> = dataStore.data.map {
-        gson.fromJson(it[TIMER_ALARM_INFO], TimerAlarmInfo::class.java)
+        it[TIMER_ALARM_INFO]?.let {
+            Json.decodeFromString<TimerAlarmInfo>(it)
+        }
     }.distinctUntilChanged()
 
     suspend fun setAlarmVolume(volume: Int) {
@@ -61,7 +63,7 @@ class TimerRepository @Inject constructor(
 
     suspend fun setTimerAlarmInfo(timerAlarmInfo: TimerAlarmInfo) {
         dataStore.edit {
-            it[TIMER_ALARM_INFO] = gson.toJson(timerAlarmInfo, TimerAlarmInfo::class.java)
+            it[TIMER_ALARM_INFO] = Json.encodeToString(timerAlarmInfo)
         }
     }
 

--- a/core/data/src/main/java/com/dev/earalarm/core/data/di/DataModule.kt
+++ b/core/data/src/main/java/com/dev/earalarm/core/data/di/DataModule.kt
@@ -6,7 +6,6 @@ import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStoreFile
 import com.dev.earalarm.core.data.TimerRepository
-import com.google.gson.Gson
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -18,12 +17,6 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 class DataModule {
 
-    @Singleton
-    @Provides
-    fun provideGson(): Gson {
-        return Gson()
-    }
-
     @Provides
     @Singleton
     fun providePreferencesDataStore(@ApplicationContext context: Context): DataStore<Preferences> =
@@ -33,8 +26,8 @@ class DataModule {
 
     @Provides
     @Singleton
-    fun provideTimerRepository(dataStore: DataStore<Preferences>, gson: Gson): TimerRepository =
-        TimerRepository(dataStore, gson)
+    fun provideTimerRepository(dataStore: DataStore<Preferences>): TimerRepository =
+        TimerRepository(dataStore)
 
     companion object {
         private const val PREFERENCES_STORE_NAME = "EarAlarmDataStore"

--- a/core/data/src/test/java/com/dev/earalarm/core/data/TimerRepositoryTest.kt
+++ b/core/data/src/test/java/com/dev/earalarm/core/data/TimerRepositoryTest.kt
@@ -5,7 +5,6 @@ import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
 import app.cash.turbine.test
 import com.dev.earalarm.core.model.TimerAlarmInfo
-import com.google.gson.Gson
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.CoroutineScope
@@ -21,7 +20,6 @@ internal class TimerRepositoryTest : StringSpec() {
     private lateinit var tempFolder: TemporaryFolder
 
     private lateinit var dataStore: DataStore<Preferences>
-    private lateinit var gson: Gson
     private lateinit var timerRepository: TimerRepository
 
     init {
@@ -34,8 +32,7 @@ internal class TimerRepositoryTest : StringSpec() {
                 scope = CoroutineScope(testDispatcher),
                 produceFile = { tempFolder.newFile("test.preferences_pb") }
             )
-            gson = Gson()
-            timerRepository = TimerRepository(dataStore, gson)
+            timerRepository = TimerRepository(dataStore)
         }
 
         afterSpec {

--- a/core/model/src/main/java/com/dev/earalarm/core/model/TimerAlarmInfo.kt
+++ b/core/model/src/main/java/com/dev/earalarm/core/model/TimerAlarmInfo.kt
@@ -1,5 +1,8 @@
 package com.dev.earalarm.core.model
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class TimerAlarmInfo(
     val minute: Int,
     val startTime: String,

--- a/feature/timer/src/main/java/com/dev/earalarm/feature/timer/measure/MeasureViewModel.kt
+++ b/feature/timer/src/main/java/com/dev/earalarm/feature/timer/measure/MeasureViewModel.kt
@@ -15,7 +15,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -45,34 +46,33 @@ class MeasureViewModel @Inject constructor(
     )
 
     init {
-        viewModelScope.launch {
-            timerRepository.alarmInfo
-                .catch { throwable ->
-                    firebaseManager.reportNonFatalError(throwable)
-                    _errorFlow.emit(throwable)
-                }.collectLatest { info ->
-                    if (info != null) {
-                        _measureUiState.update {
-                            val startTime = ZonedDateTime.parse(info.startTime)
-                            val endTime = ZonedDateTime.parse(info.endTime)
-                            it.copy(
-                                minute = info.minute,
-                                startTime = startTime,
-                                endTime = endTime,
-                                endTimeString = endTime.withZoneSameInstant(ZoneId.systemDefault())
-                                    .format(DateTimeFormatter.ofPattern("a hh:mm")),
-                                progress = getTimerProgressFromNow(startTime, endTime),
-                                leftTime = endTime.getRemainingTimeFromNow()
-                            )
-                        }
-                        measuringTimer()
-                    } else {
-                        measuringJob?.cancel()
-                        measuringJob = null
-                        _measureUiState.update { MeasureUiState() }
+        timerRepository.alarmInfo
+            .onEach { info ->
+                if (info != null) {
+                    _measureUiState.update {
+                        val startTime = ZonedDateTime.parse(info.startTime)
+                        val endTime = ZonedDateTime.parse(info.endTime)
+                        it.copy(
+                            minute = info.minute,
+                            startTime = startTime,
+                            endTime = endTime,
+                            endTimeString = endTime.withZoneSameInstant(ZoneId.systemDefault())
+                                .format(DateTimeFormatter.ofPattern("a hh:mm")),
+                            progress = getTimerProgressFromNow(startTime, endTime),
+                            leftTime = endTime.getRemainingTimeFromNow()
+                        )
                     }
+                    measuringTimer()
+                } else {
+                    measuringJob?.cancel()
+                    measuringJob = null
+                    _measureUiState.update { MeasureUiState() }
                 }
-        }
+            }.catch { throwable ->
+                firebaseManager.reportNonFatalError(throwable)
+                _errorFlow.emit(throwable)
+                timerRepository.removeTimerAlarmInfo()
+            }.launchIn(viewModelScope)
     }
 
     private fun measuringTimer() {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,9 +19,6 @@ material = "1.12.0"
 ## DataStore
 datastore = "1.1.4"
 
-## GSON
-gson = "2.10.1"
-
 ## Kotlin Symbol Processing
 ksp = "2.0.0-1.0.22"
 
@@ -103,8 +100,6 @@ coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutin
 coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutine" }
 
 datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
-
-gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
 
 play-services-ads = { group = "com.google.android.gms", name = "play-services-ads", version.ref = "googlePlayAds" }
 play-review-ktx = { group = "com.google.android.play", name = "review-ktx", version.ref = "googlePlayReview" }


### PR DESCRIPTION
## 비정상 종료 확인
<img width="870" height="511" alt="image" src="https://github.com/user-attachments/assets/7891c43d-1fd9-4764-a683-f2d56d47c673" />

- 오류 발생 버전: `v1.5.7`
- 영향을 받은 사용자: 2 (Galaxy Z Flip5, Galaxy S23 FE)

## 개요
- `v1.5.7` 업데이트 시 적용된 코드 난독화(ProGuard/R8)로 인해, 데이터 직렬화에 사용되는 `TimerAlarmInfo` 클래스의 필드명(`startTime`, `endTime` 등)이 변경됨. 이로 인해 이전 버전(`v1.5.6`)에서 저장된 데이터와 호환되지 않아 `NullPointerException`이 발생

## 오류 재현
<img width="1423" height="393" alt="image" src="https://github.com/user-attachments/assets/1fda34be-4a6a-427d-9e84-49bb08d5889a" />


## 오류 재현 시나리오
1. `v1.5.6` 앱 실행 → 유연한 업데이트 시작 → 알람 설정 (난독화 이전 데이터 저장)
2. 업데이트 완료 → `v1.5.7` 앱 실행 → 난독화 이전 데이터를 가져와 JsonString 역질렬화
3. 난독화 되어있기 때문에 필드명이 일치하지 않아 매핑 실패, startTime을 포함한 모든 데이터 null값 할당
4. TimerAlarmInfo 값 자체는 null이 아니므로 정상 진입 및 ZonedDateTime.parse() 과정에서 에러 발생

## 난독화 예외 적용 및 오류 수정
- 데이터 직렬화를 위해 혼용하던 Gson과 Kotlinx.serialization을 `Kotlinx.serialization`으로 통일하여 코드의 일관성과 안정성을 개선.
- `Kotlinx.serialization`은 `@Serializable` 어노테이션이 사용된 클래스를 난독화로부터 보호하는 규칙을 내장되어 있음. `TimerAlarmInfo`를 `@Serializable`로 관리하여 별도의 proguard rule을 추가하지 않고 필드 이름 보존.