### PR TITLE
Fix/AdActivity edgeToEdge 비활성화

### DIFF
--- a/feature/main/src/main/AndroidManifest.xml
+++ b/feature/main/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <application>
         <activity
@@ -22,6 +23,12 @@
                     android:path="/timer" />
             </intent-filter>
         </activity>
+
+        <activity
+            android:name="com.google.android.gms.ads.AdActivity"
+            android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|uiMode|screenSize|smallestScreenSize"
+            android:theme="@style/AdInspectorActivityTheme"
+            tools:replace="android:theme" />
     </application>
 
 </manifest>

--- a/feature/main/src/main/res/values-v35/themes.xml
+++ b/feature/main/src/main/res/values-v35/themes.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+
+    <style name="AdInspectorActivityTheme" parent="@android:style/Theme.Translucent" tools:ignore="ResourceName">
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+    </style>
+</resources>

--- a/feature/setting/src/main/java/com/dev/earalarm/feature/setting/utils/UriExtension.kt
+++ b/feature/setting/src/main/java/com/dev/earalarm/feature/setting/utils/UriExtension.kt
@@ -17,19 +17,24 @@ private fun Uri.getFileName(context: Context): String? {
 }
 
 fun Uri.toPath(context: Context, deleteFile: File? = null): String? {
-    val file = this.getFileName(context)?.let { File(context.filesDir, it) }
-    val inputStream = context.contentResolver.openInputStream(this)
-    val outputStream = FileOutputStream(file)
+    return try {
+        val file = this.getFileName(context)?.let { File(context.filesDir, it) }
+        val inputStream = context.contentResolver.openInputStream(this)
+        val outputStream = FileOutputStream(file)
 
-    inputStream.use { input ->
-        outputStream.use { output ->
-            input?.copyTo(output)
+        inputStream.use { input ->
+            outputStream.use { output ->
+                input?.copyTo(output)
+            }
         }
-    }
 
-    file?.let {
-        deleteFile?.delete()
-    }
+        file?.let {
+            deleteFile?.delete()
+        }
 
-    return file?.absolutePath
+        file?.absolutePath
+    } catch (e: Exception) {
+        e.printStackTrace()
+        null
+    }
 }


### PR DESCRIPTION
## 개요
- AdMob 전면 광고에서 targetSdk에서 EdgeToEdge가 적용되어 화면 전체가 광고영역으로 보이지만, 네비게이션 바로 인해서 일부 광고의 닫기 버튼이 가려지는 문제 발생
- 임시적으로 windowOptOutEdgeToEdgeEnforcement 적용하여 EdgeToEdge 비활성화
- TargetSdk 36부터는 windowOptOutEdgeToEdgeEnforcement를 사용할 수 없으므로 주의
- Admob에서는 9월 중으로 EdgeToEdge에 대응 업데이트 할 예정이라고 함.
- 알람음 설정 시 발생할 수 있는 오류에 대한 예외 처리 추가

## 관련 이슈
- https://groups.google.com/g/google-admob-ads-sdk/c/WyGsRV--EoE

## 스크린샷
<img src="https://github.com/user-attachments/assets/7c0faf54-f75e-42a5-adcc-c39410b1918a" width="200px" />
<img src="https://github.com/user-attachments/assets/872a54a2-7206-4eda-a55b-a2ff783bc1fe" width="200px" />
